### PR TITLE
Forward ncurses/wide feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ ncurses = "5.82.0"
 
 [dev-dependencies]
 rand = "0.3"
+
+[features]
+wide = ["ncurses/wide"]


### PR DESCRIPTION
Adding the "wide" feature should still work when building on windows.