### PR TITLE
Add Eq and Hash traits to Input

### DIFF
--- a/src/input.rs
+++ b/src/input.rs
@@ -1,4 +1,4 @@
-#[derive(Copy, Clone, Debug, PartialEq)]
+#[derive(Copy, Clone, Debug, PartialEq, Eq, Hash)]
 pub enum Input {
     Character(char),
     Unknown(i32),


### PR DESCRIPTION
This allows Input to be used to key hashtables, useful for implementing
keymaps and making keybindings configurable.