### PR TITLE
Add keyname method

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2"
 pdcurses-sys = "0.7"
 winreg = "0.4"
 [target.'cfg(unix)'.dependencies]
-ncurses = "5.86.0"
+ncurses = "5.87.0"
 
 [dev-dependencies]
 rand = "0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -283,6 +283,24 @@ pub fn mousemask(newmask: mmask_t, oldmask: *mut mmask_t) -> mmask_t {
     unsafe { curses::mousemask(newmask, oldmask) }
 }
 
+/// Returns a character string corresponding to the key `code`.
+///
+/// * Printable characters are displayed as themselves, e.g., a one-character string containing the
+///   key.
+/// * Control characters are displayed in the ^X notation.
+/// * DEL (character 127) is displayed as ^?.
+/// * Values above 128 are either meta characters (if the screen has not been initialized, or if
+///   meta has been called with a TRUE parameter), shown in the M-X notation, or are displayed as
+///   themselves. In the latter case, the values may not be printable; this follows the X/Open
+///   specification.
+/// * Values above 256 may be the names of the names of function keys.
+/// * Otherwise (if there is no corresponding name) the function returns `None`, to denote an
+///   error. X/Open also lists an "UNKNOWN KEY" return value, which some implementations return
+///   rather than `None`.
+pub fn keyname(code: i32) -> Option<String> {
+    platform_specific::_keyname(code)
+}
+
 /// Suspends the program for the specified number of milliseconds.
 pub fn napms(ms: i32) -> i32 {
     unsafe { curses::napms(ms) }

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -2,7 +2,7 @@
 pub mod constants;
 use self::constants::*;
 
-use ncurses::{box_, getmouse, setlocale, LcCategory, COLORS, COLOR_PAIRS};
+use ncurses::{box_, getmouse, setlocale, LcCategory, COLORS, COLOR_PAIRS, keyname};
 use ncurses::ll::{chtype, ungetch, wattroff, wattron, wattrset, MEVENT, NCURSES_ATTR_T, WINDOW};
 use ncurses::ll::wmouse_trafo;
 
@@ -47,6 +47,10 @@ pub fn _getmouse() -> Result<MEVENT, i32> {
     };
     let error = getmouse(&mut mevent);
     if error == 0 { Ok(mevent) } else { Err(error) }
+}
+
+pub fn _keyname(code: i32) -> Option<String> {
+    keyname(code)
 }
 
 pub fn _mouse_trafo(w: &mut WINDOW, y: &mut i32, x: &mut i32, to_screen: bool) {

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -2,7 +2,7 @@
 use pdcurses::*;
 use libc::c_int;
 
-use std::ffi::CString;
+use std::ffi::{CStr,CString};
 
 pub mod constants;
 use self::constants::*;
@@ -55,6 +55,20 @@ pub fn _getmouse() -> Result<MEVENT, i32> {
     };
     let error = unsafe { nc_getmouse(&mut mevent) };
     if error == 0 { Ok(mevent) } else { Err(error) }
+}
+
+pub fn _keyname(code: i32) -> Option<String> {
+    let ptr = unsafe { keyname(code) };
+    if ptr.is_null() {
+        None
+    } else {
+        unsafe {
+            // First, get a byte slice of the returned name
+            let bytes = CStr::from_ptr(ptr).to_bytes();
+            // Then assume it's proper UF8 and allocate a String for it.
+            Some(String::from_utf8_unchecked(bytes.to_vec()))
+        }
+    }
 }
 
 pub fn _mouse_trafo(w: &mut *mut WINDOW, y: &mut i32, x: &mut i32, to_screen: bool) {


### PR DESCRIPTION
`ncurses-rs` returns an `Option<String>`, so for pdcurses I allocate a String for the returned char pointer.

Documentation is taken from https://linux.die.net/man/3/keyname

Fixes #23 