### PR TITLE
Expose wget_wch dealing with wide chars

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -1,5 +1,6 @@
 use {chtype, curses, ERR, Input, platform_specific, ptr, ToChtype};
 use std::ffi::CString;
+use std::char;
 
 #[derive(Debug)]
 pub struct Window {
@@ -289,6 +290,27 @@ impl Window {
         } else {
             Some(platform_specific::to_special_keycode(i))
         }
+    }
+
+
+    /// Read wide character from the terminal associated with the window. Analogical to getch
+    #[cfg(feature = "wide")]
+    pub fn get_wch(&self) -> Option<Input> {
+        let mut result = 0;
+        let i = unsafe { curses::wget_wch(self._window, &mut result) };
+        if i < 0 {
+            None
+        } else if i == 0 {
+            match char::from_u32(result) {
+                Some(c) => Some(Input::Character(c)),
+                None => Some(Input::Unknown(result as i32)),
+            }
+        } else if (platform_specific::to_special_keycode(i) == Input::KeyCodeYes) {
+            Some(platform_specific::to_special_keycode(result as i32))
+        } else {
+            panic!("Unexpected return value from wget_wch");
+        }
+
     }
 
     /// Return the current x coordinate of the cursor


### PR DESCRIPTION
This code should work on both platforms, but I only tested it on linux and it works there.
I think `pdcurses-sys` needs to expose `wget_wch`, but the function [exists](https://github.com/Bill-Gray/PDCurses/blob/master/curses.h#L1655) in pdcurses so it shouldn't be a problem.