### PR TITLE
Updated `winreg` version for faster compile times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,7 +23,7 @@ libc = "0.2"
 
 [target.'cfg(windows)'.dependencies]
 pdcurses-sys = "0.7"
-winreg = "0.4"
+winreg = "0.5"
 [target.'cfg(unix)'.dependencies]
 ncurses = "5.89.0"
 


### PR DESCRIPTION
`winreg` depends on `winapi`, and upgrading `winreg` leads to a newer version of `winapi` with significantly shorter build times