### PR TITLE
Added pad support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -334,6 +334,11 @@ pub fn newwin(nlines: i32, ncols: i32, begy: i32, begx: i32) -> Window {
     window::new_window(window_pointer, false)
 }
 
+pub fn newpad(lines: i32, cols: i32) -> Window {
+    let window_pointer = unsafe { curses::newpad(lines, cols) };
+    window::new_pad(window_pointer)
+}
+
 /// Enables the translation of a carriage return into a newline on input.
 ///
 /// nonl() disables this. Initially, the translation does occur.

--- a/src/window.rs
+++ b/src/window.rs
@@ -9,6 +9,8 @@ pub struct Window {
     _window: curses::WINDOW,
     _stdscr: bool,
     _deleted: bool,
+    _ispad: bool,           // Just to identify if the window is a pad; not sure what would
+                            // happen if we call method of window on a pad.
 }
 
 #[cfg(windows)]
@@ -464,7 +466,11 @@ impl Window {
 
     /// Copies the window to the virtual screen.
     pub fn noutrefresh(&self) -> i32 {
-        unsafe { curses::wnoutrefresh(self._window) }
+        if !self._ispad {
+            unsafe { curses::wnoutrefresh(self._window) }
+        } else {
+            0                   // FIXME
+        }
     }
 
     /// Overlays this window on top of destination_window. This window and destination_window are
@@ -494,7 +500,58 @@ impl Window {
     /// manipulate data structures. Unless leaveok() has been enabled, the physical cursor of the
     /// terminal is left at the location of the window's cursor.
     pub fn refresh(&self) -> i32 {
-        unsafe { curses::wrefresh(self._window) }
+        if !self._ispad {
+            unsafe { curses::wrefresh(self._window) }
+        } else {
+            0               // FIXME
+        }
+    }
+
+    // The new method; other related methods may need to be added too
+    pub fn prefresh(&self,
+                    pmin_row: i32, 
+                    pmin_col: i32, 
+                    smin_row: i32, 
+                    smin_col: i32, 
+                    smax_row: i32, 
+                    smax_col: i32
+            ) -> i32 {
+        if self._ispad {
+            unsafe {
+                curses::prefresh(self._window, 
+                                      pmin_row,
+                                      pmin_col,
+                                      smin_row,
+                                      smin_col,
+                                      smax_row,
+                                      smax_col)
+            }
+        } else {
+            0               // FIXME
+        }
+    }
+
+    pub fn pnoutrefresh(&self,
+                    pmin_row: i32, 
+                    pmin_col: i32, 
+                    smin_row: i32, 
+                    smin_col: i32, 
+                    smax_row: i32, 
+                    smax_col: i32
+            ) -> i32 {
+        if self._ispad {
+            unsafe {
+                curses::pnoutrefresh(self._window, 
+                                      pmin_row,
+                                      pmin_col,
+                                      smin_row,
+                                      smin_col,
+                                      smax_row,
+                                      smax_col)
+            }
+        } else {
+            0               // FIXME
+        }
     }
 
     /// If enabled and a scrolling region is set with setscrreg(), any attempt to move off
@@ -587,6 +644,16 @@ pub fn new_window(window_pointer: WindowPointer, is_stdscr: bool) -> Window {
         _window: window_pointer,
         _stdscr: is_stdscr,
         _deleted: false,
+        _ispad: false,
+    }
+}
+
+pub fn new_pad(window_pointer: WindowPointer) -> Window {   // A pad cannot be stdscr
+    Window {
+        _window: window_pointer,
+        _stdscr: false,
+        _deleted: false,
+        _ispad: true,
     }
 }
 


### PR DESCRIPTION
There is no `pad` type currently in pancurses, but there _is_ in ncurses. Some applications may need to use this type (in fact, I'm writing one that uses it, and that's why I created this pull request). I added a few methods/functions to provide support for it. 