### PR TITLE
Remove `try!` so example compiles with 2018 edition

### DIFF
--- a/examples/newdemo.rs
+++ b/examples/newdemo.rs
@@ -251,9 +251,9 @@ fn sub_win_test(main_window: &Window, win: &Window) -> Result<(), i32> {
     let sw = w / 3;
     let sh = h / 3;
 
-    let swin1 = try!(win.derwin(sh, sw, 3, 5));
-    let swin2 = try!(win.subwin(sh, sw, by + 4, bx + 8));
-    let swin3 = try!(win.subwin(sh, sw, by + 5, bx + 11));
+    let swin1 = win.derwin(sh, sw, 3, 5)?;
+    let swin2 = win.subwin(sh, sw, by + 4, bx + 8)?;
+    let swin3 = win.subwin(sh, sw, by + 5, bx + 11)?;
 
     init_pair(8, COLOR_RED, COLOR_BLUE);
     swin1.bkgd(COLOR_PAIR(8));


### PR DESCRIPTION
With the addition of the `try` keyword in the 2018 edition of Rust, this example was failing to be compiled when using this edition (see https://github.com/rust-lang/rfcs/blob/master/text/2388-try-expr.md#breakage-of-the-try-macro).

This change fixes this, so this example now compiles when using either the 2015 or 2018 edition.