### PR TITLE
Fix `Window::mouse_trafo`'s implementation

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -4,7 +4,7 @@ use self::constants::*;
 
 use ncurses::{box_, getmouse, keyname, setlocale, LcCategory, COLORS, COLOR_PAIRS};
 use ncurses::ll::{chtype, ungetch, wattroff, wattron, wattrset, MEVENT, NCURSES_ATTR_T, WINDOW};
-use ncurses::ll::{resize_term, wgetch, wmouse_trafo};
+use ncurses::ll::{resize_term, wgetch};
 
 use libc::c_int;
 use input::Input;

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -59,12 +59,6 @@ pub fn _keyname(code: i32) -> Option<String> {
     keyname(code)
 }
 
-pub fn _mouse_trafo(w: &mut WINDOW, y: &mut i32, x: &mut i32, to_screen: bool) {
-    unsafe {
-        wmouse_trafo(w, y, x, to_screen as u8);
-    }
-}
-
 pub fn _resize_term(nlines: i32, ncols: i32) -> i32 {
     unsafe { resize_term(nlines, ncols) }
 }

--- a/src/window.rs
+++ b/src/window.rs
@@ -369,7 +369,7 @@ impl Window {
     pub fn mouse_trafo(&mut self, y: i32, x: i32, to_screen: bool) -> (i32, i32) {
         let mut mut_y = y;
         let mut mut_x = x;
-        platform_specific::_mouse_trafo(&mut self._window, &mut mut_y, &mut mut_x, to_screen);
+        unsafe { curses::wmouse_trafo(self._window, &mut mut_y, &mut mut_x, to_screen as u8); }
         (mut_y, mut_x)
     }
 

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -78,12 +78,6 @@ pub fn _keyname(code: i32) -> Option<String> {
     }
 }
 
-pub fn _mouse_trafo(w: &mut *mut WINDOW, y: &mut i32, x: &mut i32, to_screen: bool) {
-    unsafe {
-        wmouse_trafo(*w, y, x, to_screen as u8);
-    }
-}
-
 pub fn _resize_term(nlines: i32, ncols: i32) -> i32 {
     unsafe { resize_term(nlines, ncols) }
 }


### PR DESCRIPTION
This is due to ncurses-rs having a bug in the type of `wmouse_trafo`.
This is now resolved via https://github.com/jeaye/ncurses-rs/pull/175