### PR TITLE
Bump version of ncurses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ repository = "https://github.com/ihalila/pancurses"
 readme = "README.md"
 license = "MIT"
 keywords = ["pancurses", "curses", "ncurses", "pdcurses"]
-version = "0.16.1"
+version = "0.17.0"
 authors = ["Ilkka Halila <ilkka@hali.la>"]
 
 [lib]
@@ -25,7 +25,7 @@ libc = "0.2"
 pdcurses-sys = "0.7"
 winreg = "0.5"
 [target.'cfg(unix)'.dependencies]
-ncurses = "5.91.0"
+ncurses = "5.98.0"
 
 [dev-dependencies]
 rand = "0.4.2"


### PR DESCRIPTION
This is needed because we now depend on ncurses-rs version 5.98.0