### PR TITLE
Update `newterm()` to return a `Window`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,16 +43,16 @@ pub use colorpair::ColorPair;
 #[cfg(windows)]
 mod windows;
 #[cfg(windows)]
-pub use self::windows::constants::*;
-#[cfg(windows)]
 use self::windows as platform_specific;
+#[cfg(windows)]
+pub use self::windows::constants::*;
 
 #[cfg(unix)]
 mod unix;
 #[cfg(unix)]
-pub use self::unix::constants::*;
-#[cfg(unix)]
 use self::unix as platform_specific;
+#[cfg(unix)]
+pub use self::unix::constants::*;
 
 pub const OK: i32 = 0;
 pub const ERR: i32 = -1;
@@ -315,13 +315,17 @@ pub fn napms(ms: i32) -> i32 {
 ///
 /// (For the PDCurses backend it's just an alternative interface for initscr(). It always returns
 /// SP, or NULL.)
-pub fn newterm(t: Option<&str>, output: FILE, input: FILE) -> ScrPtr {
+pub fn newterm(t: Option<&str>, output: FILE, input: FILE) -> Window {
+    platform_specific::pre_init();
+
     let term_type = t.map(|x| CString::new(x).unwrap());
     let type_ptr = match term_type {
         Some(ref s) => s.as_ptr(),
         _ => std::ptr::null(),
     };
-    unsafe { curses::newterm(type_ptr, output, input) }
+    let window_pointer = unsafe { curses::newterm(type_ptr, output, input) };
+
+    window::new_window(window_pointer, true)
 }
 
 /// Creates a new window with the given number of lines, nlines and columns, ncols.


### PR DESCRIPTION
To make `newterm` useful, we need a way to access the screen object. This can be done through `stdscr()` (see #43) or by returning a `Window` from `newterm`, so that it matches `initscr`. This PR does the second option.