### PR TITLE
Add a function for resizing a Window

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -500,7 +500,7 @@ impl Window {
     /// Resizes the window to the given dimensions. Doesn't resize subwindows on pdcurses
     /// so you have to resize them yourself.
     pub fn resize(&mut self, nlines: i32, ncols: i32) -> i32 {
-        unsafe { curses::wresize(self._window, lines, cols) }
+        unsafe { curses::wresize(self._window, nlines, ncols) }
     }
 
     /// If enabled and a scrolling region is set with setscrreg(), any attempt to move off

--- a/src/window.rs
+++ b/src/window.rs
@@ -496,6 +496,12 @@ impl Window {
     pub fn refresh(&self) -> i32 {
         unsafe { curses::wrefresh(self._window) }
     }
+    
+    /// Resizes the window to the given dimensions. Doesn't resize subwindows on pdcurses
+    /// so you have to resize them yourself.
+    pub fn resize(&mut self, nlines: i32, ncols: i32) -> i32 {
+        unsafe { curses::wresize(self._window, lines, cols) }
+    }
 
     /// If enabled and a scrolling region is set with setscrreg(), any attempt to move off
     /// the bottom margin will cause all lines in the scrolling region to scroll up one line.


### PR DESCRIPTION
It is possible to resize the terminal but it is boring without being able to manually resize a window.