### PR TITLE
Use `slice::iter` instead of `into_iter` to avoid future breakage

### DIFF
--- a/examples/firework.rs
+++ b/examples/firework.rs
@@ -26,7 +26,7 @@ fn main() {
         start_color();
     }
 
-    for (i, color) in COLOR_TABLE.into_iter().enumerate() {
+    for (i, color) in COLOR_TABLE.iter().enumerate() {
         init_pair(i as i16, *color, COLOR_BLACK);
     }
 

--- a/examples/newdemo.rs
+++ b/examples/newdemo.rs
@@ -119,7 +119,7 @@ fn main() {
 
         win.attrset(Attribute::Bold);
 
-        for (i, s) in AUS_MAP.into_iter().enumerate() {
+        for (i, s) in AUS_MAP.iter().enumerate() {
             win.mvaddstr(i as i32 + 1, 8, s);
             win.refresh();
             napms(100);


### PR DESCRIPTION
`an_array.into_iter()` currently just works because of the autoref
feature, which then calls `<[T] as IntoIterator>::into_iter`. But
in the future, arrays will implement `IntoIterator`, too. In order
to avoid problems in the future, the call is replaced by `iter()`
which is shorter and more explicit.

See https://github.com/rust-lang/rust/pull/65819 for more information