### PR TITLE
Use setlocale from libc rather than ncurses-rs.

### DIFF
--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -2,17 +2,19 @@
 pub mod constants;
 use self::constants::*;
 
-use ncurses::{box_, getmouse, keyname, setlocale, LcCategory, COLORS, COLOR_PAIRS};
+use ncurses::{box_, getmouse, keyname, COLORS, COLOR_PAIRS};
 use ncurses::ll::{chtype, ungetch, wattroff, wattron, wattrset, MEVENT, NCURSES_ATTR_T, WINDOW};
 use ncurses::ll::{resize_term, wgetch};
 
-use libc::c_int;
+use libc::{c_int, setlocale, LC_ALL};
 use crate::input::Input;
 
+use std::ffi::CString;
 use std::string::FromUtf8Error;
 
 pub fn pre_init() {
-    setlocale(LcCategory::all, "");
+    let buf = CString::new("").unwrap();
+    setlocale(LC_ALL, buf.as_ptr());
 }
 
 pub fn _attron(w: WINDOW, attributes: chtype) -> i32 {

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -14,7 +14,7 @@ use std::string::FromUtf8Error;
 
 pub fn pre_init() {
     let buf = CString::new("").unwrap();
-    setlocale(LC_ALL, buf.as_ptr());
+    unsafe { setlocale(LC_ALL, buf.as_ptr()) };
 }
 
 pub fn _attron(w: WINDOW, attributes: chtype) -> i32 {


### PR DESCRIPTION
In general the values exported by ncurses-rs are not up-to-date or reliable (for example its `LC_ALL` definition differs from `libc` on some platforms).
In addition some platforms like NetBSD need special handling (it uses `__setlocale50` rather than `setlocale`). `libc` is already equiped to handle these specifics; rather than pushing more complexity in `ncurses-rs`, it may be cleaner to just use `libc`.

(In addition `setlocale` and `LC_ALL` don't really belong in ncurses, they are defined by the system's libc, so it may not make sense for ncurses-rs to export them at all.)