### PR TITLE
fix all warnings & lints

### DIFF
--- a/examples/newdemo.rs
+++ b/examples/newdemo.rs
@@ -151,10 +151,7 @@ fn main() {
                     let char_index = visbuf_i as i32 - i;
                     let ch = if char_index >= 0 && char_index < message.len() as i32 {
                         let char_index = char_index as usize;
-                        match message[char_index..char_index + 1].chars().next() {
-                            Some(c) => c,
-                            None => ' ',
-                        }
+                        message[char_index..char_index + 1].chars().next().unwrap_or(' ')
                     } else {
                         ' '
                     };
@@ -237,10 +234,7 @@ fn wait_for_user(main_window: &Window) -> bool {
     nocbreak(); // Reset the halfdelay() value
     cbreak();
 
-    match ch {
-        Some(Input::Character('\x1B')) => true,
-        _ => false,
-    }
+    matches!(ch, Some(Input::Character('\x1B')))
 }
 
 fn sub_win_test(main_window: &Window, win: &Window) -> Result<(), i32> {

--- a/examples/newtest.rs
+++ b/examples/newtest.rs
@@ -22,7 +22,7 @@ fn main() {
 
     set_title("NewTest: tests various pancurses features");
 
-    mousemask(ALL_MOUSE_EVENTS, std::ptr::null_mut());
+    mousemask(ALL_MOUSE_EVENTS, None);
 
     window.attrset(COLOR_PAIR(1));
 

--- a/examples/rain.rs
+++ b/examples/rain.rs
@@ -1,3 +1,5 @@
+#![allow(clippy::many_single_char_names)]
+
 /// **************************************************************************
 /// Copyright (c) 2002 Free Software Foundation, Inc.                        *
 ///                                                                          *

--- a/src/attributes.rs
+++ b/src/attributes.rs
@@ -72,6 +72,7 @@ impl Attributes {
     }
     attribute_setter!(set_dim, A_DIM);
 
+    #[cfg_attr(unix, allow(clippy::bad_bit_mask))]
     pub fn is_leftline(&self) -> bool {
         (self.raw & A_LEFTLINE) > 0
     }
@@ -94,6 +95,7 @@ impl Attributes {
         self.raw = 0
     }
 
+    #[cfg_attr(unix, allow(clippy::bad_bit_mask))]
     pub fn is_overline(&self) -> bool {
         (self.raw & A_OVERLINE) > 0
     }
@@ -104,11 +106,13 @@ impl Attributes {
     }
     attribute_setter!(set_reverse, A_REVERSE);
 
+    #[cfg_attr(unix, allow(clippy::bad_bit_mask))]
     pub fn is_rightline(&self) -> bool {
         (self.raw & A_RIGHTLINE) > 0
     }
     attribute_setter!(set_rightline, A_RIGHTLINE);
 
+    #[cfg_attr(unix, allow(clippy::bad_bit_mask))]
     pub fn is_strikeout(&self) -> bool {
         (self.raw & A_STRIKEOUT) > 0
     }
@@ -124,7 +128,7 @@ impl Attributes {
     }
     pub fn set_color_pair(&mut self, color_pair: ColorPair) {
         let color_chtype: chtype = color_pair.into();
-        self.raw = self.raw | color_chtype;
+        self.raw |= color_chtype;
         self.color_pair = color_pair;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -278,8 +278,9 @@ pub fn mouseinterval(interval: i32) -> i32 {
 ///
 /// As a side effect, setting a zero mousemask may turn off the mouse pointer; setting a nonzero
 /// mask may turn it on. Whether this happens is device-dependent.
-pub fn mousemask(newmask: mmask_t, oldmask: *mut mmask_t) -> mmask_t {
-    unsafe { curses::mousemask(newmask, oldmask) }
+pub fn mousemask(newmask: mmask_t, oldmask: Option<&mut mmask_t>) -> mmask_t {
+    let oldmask_ptr = oldmask.map(|x| x as *mut _).unwrap_or(std::ptr::null_mut());
+    unsafe { curses::mousemask(newmask, oldmask_ptr) }
 }
 
 /// Returns a character string corresponding to the key `code`.

--- a/src/unix/constants.rs
+++ b/src/unix/constants.rs
@@ -67,16 +67,16 @@ pub const COLOR_CYAN: i16 = 6;
 pub const COLOR_WHITE: i16 = 7;
 
 pub const A_ALTCHARSET: attr_t = (1u32 << (14u32 + NCURSES_ATTR_SHIFT)) as attr_t;
-pub const A_ATTRIBUTES: attr_t = (!0u32 << (0u32 + NCURSES_ATTR_SHIFT)) as attr_t;
+pub const A_ATTRIBUTES: attr_t = (!0u32 << NCURSES_ATTR_SHIFT) as attr_t;
 pub const A_BLINK: attr_t = (1u32 << (11u32 + NCURSES_ATTR_SHIFT)) as attr_t;
 pub const A_BOLD: attr_t = (1u32 << (13u32 + NCURSES_ATTR_SHIFT)) as attr_t;
-pub const A_CHARTEXT: attr_t = (1u32 << (0u32 + NCURSES_ATTR_SHIFT)) as attr_t;
-pub const A_COLOR: attr_t = ((((1u32) << 8) - 1u32) << (0u32 + NCURSES_ATTR_SHIFT)) as attr_t;
+pub const A_CHARTEXT: attr_t = (1u32 << NCURSES_ATTR_SHIFT) as attr_t;
+pub const A_COLOR: attr_t = ((((1u32) << 8) - 1u32) << NCURSES_ATTR_SHIFT) as attr_t;
 pub const A_DIM: attr_t = (1u32 << (12u32 + NCURSES_ATTR_SHIFT)) as attr_t;
 pub const A_ITALIC: attr_t = (1u32 << (23 + NCURSES_ATTR_SHIFT)) as attr_t;
 pub const A_INVIS: attr_t = (1u32 << (15u32 + NCURSES_ATTR_SHIFT)) as attr_t;
 pub const A_LEFTLINE: attr_t = 0; // Not supported on ncurses
-pub const A_NORMAL: attr_t = 0u32 as attr_t;
+pub const A_NORMAL: attr_t = 0;
 pub const A_OVERLINE: attr_t = 0; // Not supported on ncurses
 pub const A_REVERSE: attr_t = (1u32 << (10 + NCURSES_ATTR_SHIFT)) as attr_t;
 pub const A_RIGHTLINE: attr_t = 0; // Not supported on ncurses
@@ -84,11 +84,11 @@ pub const A_STANDOUT: attr_t = (1u32 << (8 + NCURSES_ATTR_SHIFT)) as attr_t;
 pub const A_STRIKEOUT: attr_t = 0; // Not supported on ncurses
 pub const A_UNDERLINE: attr_t = (1u32 << (9 + NCURSES_ATTR_SHIFT)) as attr_t;
 
-pub const KEY_RESIZE: i32 = 0632;
+pub const KEY_RESIZE: i32 = 0o632;
 
 pub const KEY_OFFSET: i32 = 0o0400;
-pub const KEY_F15: i32 = (KEY_OFFSET + 0x17);
-pub const KEY_EVENT: i32 = (KEY_OFFSET + 0o633);
+pub const KEY_F15: i32 = KEY_OFFSET + 0x17;
+pub const KEY_EVENT: i32 = KEY_OFFSET + 0o633;
 
 pub const SPECIAL_KEY_CODES: [Input; 108] = [
     Input::KeyCodeYes,

--- a/src/unix/mod.rs
+++ b/src/unix/mod.rs
@@ -92,14 +92,14 @@ pub fn _ungetch(input: &Input) -> i32 {
             let mut utf8_buffer = [0; 4];
             c.encode_utf8(&mut utf8_buffer)
                 .as_bytes()
-                .into_iter()
+                .iter()
                 .rev()
                 .map(|x| unsafe { ungetch(*x as c_int) })
-                .fold(0, |res, x| i32::min(res, x))
+                .fold(0, |res, x| res.min(x))
         }
         Input::Unknown(i) => unsafe { ungetch(i) },
         specialKeyCode => {
-            for (i, skc) in SPECIAL_KEY_CODES.into_iter().enumerate() {
+            for (i, skc) in SPECIAL_KEY_CODES.iter().enumerate() {
                 if *skc == specialKeyCode {
                     let result = i as c_int + KEY_OFFSET;
                     if result <= KEY_F15 {
@@ -177,12 +177,12 @@ mod tests {
             'ე', 'პ', 'ხ', 'இ', 'ங', 'க', 'ಬ', 'ಇ', 'ಲ', 'ಸ',
         ];
 
-        chars.into_iter().for_each(|c| {
+        chars.iter().for_each(|c| {
             _ungetch(&Input::Character(*c));
             assert_eq!(_wgetch(w).unwrap(), Input::Character(*c));
         });
 
-        SPECIAL_KEY_CODES.into_iter().for_each(|i| {
+        SPECIAL_KEY_CODES.iter().for_each(|i| {
             _ungetch(i);
             assert_eq!(_wgetch(w).unwrap(), *i);
         });

--- a/src/window.rs
+++ b/src/window.rs
@@ -95,6 +95,7 @@ impl Window {
     }
 
     /// Draw a border around the edges of the window.
+    #[allow(clippy::too_many_arguments)]
     pub fn border<T: ToChtype>(
         &self,
         left_side: T,
@@ -164,6 +165,7 @@ impl Window {
     /// "overlay", if TRUE, indicates that the copy is done non-destructively (as in overlay());
     /// blanks in the source window are not copied to the destination window. When overlay is
     /// FALSE, blanks are copied.
+    #[allow(clippy::too_many_arguments)]
     pub fn copywin(
         &self,
         destination_window: &Window,

--- a/src/windows/constants.rs
+++ b/src/windows/constants.rs
@@ -35,10 +35,10 @@ pub const A_STRIKEOUT: chtype = 0x200 << PDC_CHARTEXT_BITS;
 pub const A_UNDERLINE: chtype = 0x010 << PDC_CHARTEXT_BITS;
 
 pub const KEY_OFFSET: i32 = 0xec00;
-pub const KEY_F15: i32 = (KEY_OFFSET + 0x17);
-pub const KEY_UNDO: i32 = (KEY_OFFSET + 0x96);
-pub const KEY_RESIZE: i32 = (KEY_OFFSET + 0x122);
-pub const KEY_MOUSE: i32 = (KEY_OFFSET + 0x11b);
+pub const KEY_F15: i32 = KEY_OFFSET + 0x17;
+pub const KEY_UNDO: i32 = KEY_OFFSET + 0x96;
+pub const KEY_RESIZE: i32 = KEY_OFFSET + 0x122;
+pub const KEY_MOUSE: i32 = KEY_OFFSET + 0x11b;
 
 pub const KEY_NUMPAD_UP: i32 = 60610;
 pub const KEY_NUMPAD_DOWN: i32 = 60616;


### PR DESCRIPTION
Mostly these are style fixes, but there are two significant changes:

- `KEY_RESIZE` was written as `0632`, but this isn't an octal literal as intended, so the value was actually wrong.
- `mousemask` now takes an `Option<&mut mmask_t>` instead of `*mut mmask_t`, which makes it safe while maintaining the same semantics. Functions that take a pointer as an argument but are not marked `unsafe` are wrong because the code can't check the validity of the caller-supplied pointer that's about to be dereferenced.

I squelched `clippy::bad_bit_mask` for Unix-only in a few places, because we're doing a bitwise mask with constants that are zero on Unix but not zero on Windows.