### PR TITLE
Added docstring warning for multi-byte characters

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -19,7 +19,8 @@ impl Window {
     /// Adds the chtype ch to the window at the current cursor position, and advances the cursor.
     ///
     /// Note that chtypes can convey both text (a single character) and attributes, including a
-    /// color pair.
+    /// color pair. Does not support multi-byte unicode characters. Multi-byte characters should
+    /// be added with [`addstr`](Window::addstr).
     pub fn addch<T: ToChtype>(&self, ch: T) -> i32 {
         unsafe { curses::waddch(self._window, ch.to_chtype()) }
     }
@@ -383,6 +384,8 @@ impl Window {
     }
 
     /// moves the cursor to the specified position and adds ch to the specified window
+    /// Does not support multi-byte unicode characters. Multi-byte characters should
+    /// be added with [`mvaddstr`](Window::mvaddstr).
     pub fn mvaddch<T: ToChtype>(&self, y: i32, x: i32, ch: T) -> i32 {
         unsafe { curses::mvwaddch(self._window, y, x, ch.to_chtype()) }
     }


### PR DESCRIPTION
I wasn't aware of the issues with multi-byte characters until I found [this issue](https://github.com/ihalila/pancurses/issues/35#issuecomment-368338996), so it's probably worth adding a warning to the documentation.

I looked into possible fixes, but unfortunately it seems like a message in the docs is the best fix I can think of. Otherwise it becomes a mess of type conversions or ends up with unnecessary methods that are just clones of `addstr`.