### PR TITLE
Mark _attron function as unsafe

### DIFF
--- a/src/window.rs
+++ b/src/window.rs
@@ -66,17 +66,17 @@ impl Window {
 
     /// Turns off the named attributes without affecting any other attributes.
     pub fn attroff<T: Into<chtype>>(&self, attributes: T) -> i32 {
-        platform_specific::_attroff(self._window, attributes.into())
+        unsafe { platform_specific::_attroff(self._window, attributes.into()) }
     }
 
     /// Turns on the named attributes without affecting any other attributes.
     pub fn attron<T: Into<chtype>>(&self, attributes: T) -> i32 {
-        platform_specific::_attron(self._window, attributes.into())
+        unsafe { platform_specific::_attron(self._window, attributes.into()) }
     }
 
     /// Sets the current attributes of the given window to attributes.
     pub fn attrset<T: Into<chtype>>(&self, attributes: T) -> i32 {
-        platform_specific::_attrset(self._window, attributes.into())
+        unsafe { platform_specific::_attrset(self._window, attributes.into()) }
     }
 
     /// Not only change the background, but apply it immediately to every cell in the window.
@@ -228,7 +228,7 @@ impl Window {
     /// Draw a border around the edge of the window. If any argument is zero, an appropriate
     /// default is used.
     pub fn draw_box<T: ToChtype>(&self, verch: T, horch: T) -> i32 {
-        platform_specific::_draw_box(self._window, verch.to_chtype(), horch.to_chtype())
+        unsafe { platform_specific::_draw_box(self._window, verch.to_chtype(), horch.to_chtype()) }
     }
 
     /// Creates an exact duplicate of the window.

--- a/src/windows/mod.rs
+++ b/src/windows/mod.rs
@@ -24,16 +24,16 @@ use self::win32 as flavor;
 
 pub use self::flavor::pre_init;
 
-pub fn _attron(w: *mut WINDOW, attributes: chtype) -> i32 {
-    unsafe { wattron(w, attributes) }
+pub unsafe fn _attron(w: *mut WINDOW, attributes: chtype) -> i32 {
+    wattron(w, attributes) 
 }
 
-pub fn _attroff(w: *mut WINDOW, attributes: chtype) -> i32 {
-    unsafe { wattroff(w, attributes) }
+pub unsafe fn _attroff(w: *mut WINDOW, attributes: chtype) -> i32 {
+    wattroff(w, attributes) 
 }
 
-pub fn _attrset(w: *mut WINDOW, attributes: chtype) -> i32 {
-    unsafe { wattrset(w, attributes) }
+pub unsafe fn _attrset(w: *mut WINDOW, attributes: chtype) -> i32 {
+    wattrset(w, attributes)
 }
 
 pub fn _COLORS() -> i32 {
@@ -44,8 +44,8 @@ pub fn _COLOR_PAIRS() -> i32 {
     unsafe { COLOR_PAIRS }
 }
 
-pub fn _draw_box(w: *mut WINDOW, verch: chtype, horch: chtype) -> i32 {
-    unsafe { _box(w, verch, horch) }
+pub unsafe fn _draw_box(w: *mut WINDOW, verch: chtype, horch: chtype) -> i32 {
+    _box(w, verch, horch)
 }
 
 pub fn _getmouse() -> Result<MEVENT, i32> {


### PR DESCRIPTION
https://github.com/ihalila/pancurses/blob/274e270588d4f3fda2332179796b741a110d893a/src/unix/mod.rs#L20-L22
Hello, this function needs to add the unsafe keyword, because it calls another unverified C function wattron, which is an unsafe operation..

It is not a good choice to mark the entire function body as unsafe, which will make the caller ignore the safety requirements that the function parameters must guarantee, the developer who calls the _attron function may not notice this safety requirement, if a function's entire body is unsafe, the function is itself unsafe and should be marked appropriately

Marking them unsafe also means that callers must make sure they know what they're doing.