### PR TITLE
make `pancurses` work with `ncurses` 6.0.1

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 .project
 Cargo.lock
 .settings/
+rustc-ice-*.txt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ libc = "0.2"
 pdcurses-sys = "0.7"
 winreg = "0.5"
 [target.'cfg(unix)'.dependencies]
-ncurses = "5.101.0"
+ncurses = "6.0.1"
 
 [dev-dependencies]
 rand = "0.8.4"

--- a/src/unix/constants.rs
+++ b/src/unix/constants.rs
@@ -62,28 +62,28 @@ pub use ncurses::COLOR_RED;
 pub use ncurses::COLOR_WHITE;
 pub use ncurses::COLOR_YELLOW;
 
-pub const A_ALTCHARSET: attr_t = ncurses::A_ALTCHARSET();
-pub const A_ATTRIBUTES: attr_t = ncurses::A_ATTRIBUTES();
-pub const A_BLINK: attr_t = ncurses::A_BLINK();
-pub const A_BOLD: attr_t = ncurses::A_BOLD();
-pub const A_CHARTEXT: attr_t = ncurses::A_CHARTEXT();
-pub const A_COLOR: attr_t = ncurses::A_COLOR();
-pub const A_DIM: attr_t = ncurses::A_DIM();
-pub const A_ITALIC: attr_t = ncurses::A_ITALIC();
-pub const A_INVIS: attr_t = ncurses::A_INVIS();
+pub const A_ALTCHARSET: attr_t = ncurses::A_ALTCHARSET;
+pub const A_ATTRIBUTES: attr_t = ncurses::A_ATTRIBUTES;
+pub const A_BLINK: attr_t = ncurses::A_BLINK;
+pub const A_BOLD: attr_t = ncurses::A_BOLD;
+pub const A_CHARTEXT: attr_t = ncurses::A_CHARTEXT;
+pub const A_COLOR: attr_t = ncurses::A_COLOR;
+pub const A_DIM: attr_t = ncurses::A_DIM;
+pub const A_ITALIC: attr_t = ncurses::A_ITALIC;
+pub const A_INVIS: attr_t = ncurses::A_INVIS;
 pub const A_LEFTLINE: attr_t = 0; // Not supported on ncurses
-pub const A_NORMAL: attr_t = ncurses::A_NORMAL();
+pub const A_NORMAL: attr_t = ncurses::A_NORMAL;
 pub const A_OVERLINE: attr_t = 0; // Not supported on ncurses
-pub const A_REVERSE: attr_t = ncurses::A_REVERSE();
+pub const A_REVERSE: attr_t = ncurses::A_REVERSE;
 pub const A_RIGHTLINE: attr_t = 0; // Not supported on ncurses
-pub const A_STANDOUT: attr_t = ncurses::A_STANDOUT();
+pub const A_STANDOUT: attr_t = ncurses::A_STANDOUT;
 pub const A_STRIKEOUT: attr_t = 0; // Not supported on ncurses
-pub const A_UNDERLINE: attr_t = ncurses::A_UNDERLINE();
+pub const A_UNDERLINE: attr_t = ncurses::A_UNDERLINE;
 
 pub const KEY_OFFSET: i32 = 0o0400;
 pub const KEY_RESIZE: i32 = ncurses::KEY_RESIZE;
-pub const KEY_F15: i32 = ncurses::KEY_F15;
-pub const KEY_EVENT: i32 = ncurses::KEY_EVENT;
+pub const KEY_F15: i32 = ncurses::KEY_F(15);
+//pub const KEY_EVENT: i32 = ncurses::KEY_EVENT; // doesn't exist anymore in /usr/include/ncurses.h -> curses.h of ncurses 6.4_p20230401 (gentoo) or in ncurses-rs https://github.com/jeaye/ncurses-rs/pull/201/files#diff-b9f534f90cc01f9fbdcf768139ee60ac1e0c33b114024029c8e2f3f1e32c8a97L215
 
 pub const SPECIAL_KEY_CODES: [Input; 108] = [
     Input::KeyCodeYes,

--- a/src/window.rs
+++ b/src/window.rs
@@ -30,8 +30,8 @@ impl Window {
     ///
     /// The functionality is similar to calling window.addch() once for each character in the
     /// string.
-	pub fn addstr<T: AsRef<str>>(&self, string: T) -> i32 {
-		let s = CString::new(string.as_ref()).unwrap();
+    pub fn addstr<T: AsRef<str>>(&self, string: T) -> i32 {
+        let s = CString::new(string.as_ref()).unwrap();
         unsafe { curses::waddstr(self._window, s.as_ptr()) }
     }
 
@@ -372,7 +372,9 @@ impl Window {
     pub fn mouse_trafo(&self, y: i32, x: i32, to_screen: bool) -> (i32, i32) {
         let mut mut_y = y;
         let mut mut_x = x;
-        unsafe { curses::wmouse_trafo(self._window, &mut mut_y, &mut mut_x, to_screen as u8); }
+        unsafe {
+            curses::wmouse_trafo(self._window, &mut mut_y, &mut mut_x, to_screen as u8);
+        }
         (mut_y, mut_x)
     }
 
@@ -444,12 +446,11 @@ impl Window {
         unsafe { curses::mvwinsch(self._window, y, x, ch.to_chtype()) }
     }
 
-
     /// Add a string to the window at the specified cursor position.
     pub fn mvprintw<T: AsRef<str>>(&self, y: i32, x: i32, string: T) -> i32 {
         let s = CString::new(string.as_ref()).unwrap();
         //XXX: extracted to variable 'ps' due to false positive warning https://github.com/rust-lang/rust/issues/78691
-        let ps = CString::new("%s").unwrap();//FIXME: find a better way
+        let ps = CString::new("%s").unwrap(); //FIXME: find a better way
         unsafe { curses::mvwprintw(self._window, y, x, ps.as_ptr(), s.as_ptr()) }
         //unsafe { curses::mvwprintw(self._window, y, x, CString::new("%s").unwrap().as_ptr(), s.as_ptr()) }
     }
@@ -492,7 +493,7 @@ impl Window {
     pub fn printw<T: AsRef<str>>(&self, string: T) -> i32 {
         let s = CString::new(string.as_ref()).unwrap();
         //XXX: extracted to variable 'ps' due to false positive warning https://github.com/rust-lang/rust/issues/78691
-        let ps = CString::new("%s").unwrap();//FIXME: find a better way
+        let ps = CString::new("%s").unwrap(); //FIXME: find a better way
         unsafe { curses::wprintw(self._window, ps.as_ptr(), s.as_ptr()) }
     }
 
@@ -505,7 +506,7 @@ impl Window {
     pub fn refresh(&self) -> i32 {
         unsafe { curses::wrefresh(self._window) }
     }
-    
+
     /// Resizes the window to the given dimensions. Doesn't resize subwindows on pdcurses
     /// so you have to resize them yourself.
     pub fn resize(&mut self, nlines: i32, ncols: i32) -> i32 {


### PR DESCRIPTION
<del>but first, `ncurses-rs` needs the changes in this PR : https://github.com/jeaye/ncurses-rs/pull/220 (but the below were tested only with PR https://github.com/jeaye/ncurses-rs/pull/218 which is a superset PR which handles more error cases/warnings and overall improves build, I'll have to retest depending on which PR, if ever, gets merged)</del>
this got in https://github.com/jeaye/ncurses-rs/pull/220 as v6.0.1 (already on `crates.io`), so I'm testing with this version.

Note: `KEY_EVENT` went away, though it wasn't used anywhere in `pancurses`.

Closes #92 

- [x] compiles and passes `cargo test`
- [x] examples compile and run eg. `cargo run --example`...
- [x] examples appear to run correctly, except:
  - [x] `cargo run --example newtest`, has text under the color box, was it the same with v5 ? yes, it was, overlayed the screens look identical on v5 and on v6 now.
  - [x] `cargo run --example newtest` only shows the correct text in the other languages on NixOS, this appears to be due to `ncursesw` being selected there by `pkg-config` for some reason, not on Fedora/Gentoo which select `ncurses` - and I didn't force with any features like `wide` (if I do, it works on those 2 also: ie. `cargo run --example newtest --features wide`)
- [x] check if uses of `mvprintw` and `printw` by `pancurses` were using formatting before, since they can't anymore in v6. Ok, it wasn't possible to use formatting before, due to no extra args could've been supplied to fulfill the requested formatting; this got [fixed](https://github.com/jeaye/ncurses-rs/commit/8fd11147ec9cc85d07a21f71afd07874e06f4a5f) in `ncurses-rs` so that the unformatted string that was used(as the only arg) won't segfault anymore if `%` was in it.
- [x] try features via `cargo test`
  - [x] no feature specifier (eg. default?)
  - [x] only `wide`
  - [x] only `show_menu`
  - [x] only `disable_resize`
  - [x]  all 3 at once

Legend:
- ❌ = known not to work
- [ ] = untested
- [x] = works

The above are checked to be true on:
- [x] Gentoo 2.15 default/linux/amd64/23.0/split-usr/no-multilib (stable)
- [ ] NixOS (if `PKG_CONFIG_PATH` is set to the dir containing `ncurses.pc` file)
- [ ] Fedora 39
- [ ] Windows 11 x64 (cmd.exe) (must not use `--all-features` because then `win32` and `win32a` will both be used and fail compilation)
- [ ] FreeBSD 14.0-RELEASE
  - [x] examples work with `TERM=xterm-256color` but are broken with `TERM=xterm`, via ssh using `alacritty` terminal (freebsd doesn't have `alacritty` in term database, so had to change it to can compile `ncurses-rs` aka ncurses crate).
- [ ] OpenBSD 7.5 GENERIC
  - [x] needs one of `LC_CTYPE=en_US.UTF-8` or `LANG=en_US.UTF-8` to be set otherwise it looks as if it doesn't have wide chars support so `cursive` and `pancuses` examples look pretty broken.
- [ ] MacOS Mojave v10.14.6 (with [this](https://github.com/gyscos/cursive/wiki/Install-ncurses#macos))
- [ ] Windows 11 WSL1 [Arch Linux](https://github.com/yuk7/ArchWSL) Linux DESKTOP 4.4.0-22621-Microsoft #2506-Microsoft Fri Jan 01 08:00:00 PST 2016 x86_64 GNU/Linux


TODO:
- [ ] bump the version of `pancurses` to reflect these changes, `0.18`? (or leave this to the repo owner to do)
- [x] use exact `ncurses-rs` version in `Cargo.toml` after it gets published, ie. so it's not lower than that version, because then it would break compilation of `pancurses`
- [x] squash the first 3 commits into one, keep the rustfmt one after, separate.
- [ ] run `cargo clippy` and fix:
  - [ ] errors
    - [ ] introduced due to this PR
    - [ ] pre this PR errors
      - [ ] `error: this public function might dereference a raw pointer but is not marked unsafe`
        - [ ] `unsafe { curses::delscreen(screen) }`
        - [ ] `unsafe { curses::newterm(type_ptr, output, input) }`
        - [ ] `unsafe { curses::newterm(type_ptr, output, input) }`
        - [ ] `unsafe { curses::set_term(new) }`
      - [ ] might be more errors but my limit is 5 due to `-Z treat-err-as-bug=5`
  - [ ] warnings
    - [ ] introduced due to this PR
    - [ ] pre this PR warnings
      - [ ] `warning: name `FILE` contains a capitalized acronym`
- [x] I'm watching(github notifications All Activity) the entire repo for any future-reported breakage, to address it.
- [x] [KEY_EVENT](https://github.com/ihalila/pancurses/pull/93/files#diff-500884924f847cfb99e14f81dadf75f86f96e8ff647cdd9e71a929a85d482b64R86) went away, go-ncurses also [commented](https://github.com/seehuhn/go-ncurses/commit/c694e8edeef5ddc70e98d719f040b7db550ba8bd) it out.